### PR TITLE
Update outdated repo server hostname

### DIFF
--- a/mesos-image/agent/Dockerfile
+++ b/mesos-image/agent/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Container Solutions BV <info@container-solutions.com>
 ARG MESOS_VERSION
 ENV VERSION ${MESOS_VERSION}
 
-RUN echo "deb http://repos.mesosphere.io/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
+RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get update && \
     apt-get -y install mesos=${VERSION} && \

--- a/mesos-image/master/Dockerfile
+++ b/mesos-image/master/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Container Solutions BV <info@container-solutions.com>
 ARG MESOS_VERSION
 ENV VERSION ${MESOS_VERSION}
 
-RUN echo "deb http://repos.mesosphere.io/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
+RUN echo "deb http://repos.mesosphere.com/ubuntu trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get update && \
     apt-get -y install mesos=${VERSION} && \


### PR DESCRIPTION
Just an update to the repo hostname. The .io domain has been deprecated a while ago and just left working for backwards compatibility.
